### PR TITLE
Add wildcard certificate support to MS CA certificate creation

### DIFF
--- a/CreateMsCaCertificate.yml
+++ b/CreateMsCaCertificate.yml
@@ -18,7 +18,7 @@
     pfx_password: "DeleteMe" #This is not really used but it is required by the CA
     ca_config: "{{ hostvars['localhost']['certificateauthority_info'].ca_config }}"
     cert_template: "{{ hostvars['localhost']['certificateauthority_info'].cert_template }}"
-    cert_folder: "C:\\CertStuff\\{{ ServerName }}"
+    cert_folder: "C:\\CertStuff\\{{ 'wildcard.' + ServerName if Wildcard | bool else ServerName }}"
   tasks:
     - name: Run the Role
       include_role:

--- a/roles/CreateMsCaCertificate/defaults/main.yml
+++ b/roles/CreateMsCaCertificate/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+Wildcard: false

--- a/roles/CreateMsCaCertificate/tasks/main.yml
+++ b/roles/CreateMsCaCertificate/tasks/main.yml
@@ -36,7 +36,7 @@
   # We filter by matching the Subject to the CN. Adjust if your subject is different.
   win_shell: >
     $thumb = (Get-ChildItem -Path Cert:\\LocalMachine\\My |
-      Where-Object { $_.Subject -like "*CN={{ ServerName }}*" } |
+      Where-Object { $_.Subject -like "*CN={{ '*.' + ServerName if Wildcard | bool else ServerName + '.evorigin.com' }}*" } |
       Select-Object -Last 1).Thumbprint;
     Write-Host $thumb
   register: cert_thumbprint

--- a/roles/CreateMsCaCertificate/templates/request.inf.j2
+++ b/roles/CreateMsCaCertificate/templates/request.inf.j2
@@ -1,5 +1,5 @@
 [NewRequest]
-Subject = "CN={{ ServerName }}.evorigin.com, O=EvOrigin, OU=Lab, L=Jax, ST=FL, C=US"
+Subject = "CN={{ '*.' + ServerName if Wildcard | bool else ServerName + '.evorigin.com' }}, O=EvOrigin, OU=Lab, L=Jax, ST=FL, C=US"
 KeyLength = "{{ KeyLength }}"
 KeySpec = 1
 KeyUsage = 0xA0  ; Digital Signature, Key Encipherment
@@ -17,7 +17,7 @@ _continue_ = "CA=FALSE"
 
 ; Subject Alternative Name
 2.5.29.17 = "{text}"
-_continue_ = "DNS={{ ServerName }}.evorigin.com"
+_continue_ = "DNS={{ '*.' + ServerName if Wildcard | bool else ServerName + '.evorigin.com' }}"
 
 [RequestAttributes]
 CertificateTemplate = "{{ cert_template }}"


### PR DESCRIPTION
## Summary
This PR adds support for generating wildcard SSL certificates through the MS CA certificate creation role. A new `Wildcard` boolean parameter controls whether certificates are created as wildcard certificates or standard certificates.

## Key Changes
- Added `Wildcard` parameter (defaults to `false`) in role defaults
- Updated certificate Subject CN generation to prepend `*.` when wildcard mode is enabled
- Updated Subject Alternative Name (SAN) DNS entry to use wildcard format when applicable
- Modified certificate folder naming to include `wildcard.` prefix for wildcard certificates
- Updated certificate thumbprint lookup to match the dynamically generated CN value

## Implementation Details
- The wildcard logic uses Jinja2 conditional expressions: `'*.' + ServerName if Wildcard | bool else ServerName + '.evorigin.com'`
- This ensures consistent naming across the certificate request template, folder structure, and certificate lookup
- The change is backward compatible - existing playbooks will continue to generate standard certificates with `Wildcard: false` as the default

https://claude.ai/code/session_01F4hJARJTMd1DoMVFzLSw9s